### PR TITLE
feat: add SkillTreeLayout

### DIFF
--- a/src/game/main/basic/ui/GameLayout.cpp
+++ b/src/game/main/basic/ui/GameLayout.cpp
@@ -5,6 +5,7 @@
 #include "PhoneLayout.h"
 #include "MapLayout.h"
 #include "SettingsLayout.h"
+#include "SkillTreeLayout.h"
 #include "../Game.h"
 #include "../Dialog.h"
 #include "../StoryController.h"
@@ -30,6 +31,7 @@ GameLayout::GameLayout(Game& game_logic) : game_logic_(game_logic),
     shopLayout_ = Make<ShopLayout>(game_logic_, showShop_);
     infoLayout_ = Make<UserInfoLayout>(game_logic_, showInfo_);
     settingsLayout_ = Make<SettingsLayout>(game_logic_, showSettings_);
+    skillTreeLayout_ = Make<SkillTreeLayout>(game_logic_, showSkillTree_);
 
     phoneLayout_ = Make<PhoneLayout>(
         game_logic_,
@@ -174,7 +176,7 @@ GameLayout::GameLayout(Game& game_logic) : game_logic_(game_logic),
         if(auto* settingsPtr = dynamic_cast<SettingsLayout*>(settingsLayout_.get())) { settingsPtr->loadSettings(); }
         showSettings_ = true; }, ButtonOption::Animated());
     auto buttonBag = Button("   背包  ", [&] { showBag_ = true; }, ButtonOption::Animated());
-    auto buttonSchedule = Button(" 我的日程 ", []{}, ButtonOption::Animated());
+    auto buttonSkillTree = Button("  技能树  ", [&] { showSkillTree_ = true; }, ButtonOption::Animated()); // 替换
     auto buttonExitToMainMenu = Button(" 回到主界面 ", [&] {
         game_logic_.getDialog().clearHistory();
         game_logic_.getDialog().addMessage("<SYSTEM>", "欢迎回来");
@@ -186,7 +188,7 @@ GameLayout::GameLayout(Game& game_logic) : game_logic_(game_logic),
         buttonPhone,
         buttonSettings,
         buttonBag,
-        buttonSchedule,
+        buttonSkillTree,
         buttonExitToMainMenu,
     });
 
@@ -276,7 +278,8 @@ GameLayout::GameLayout(Game& game_logic) : game_logic_(game_logic),
         Maybe(mapLayout_, &showMap_),
         Maybe(shopLayout_, &showShop_),
         Maybe(infoLayout_, &showInfo_),
-        Maybe(settingsLayout_, &showSettings_)
+        Maybe(settingsLayout_, &showSettings_),
+        Maybe(skillTreeLayout_, &showSkillTree_)
     });
 
     // 将这个顶层容器作为 GameLayout 的子组件
@@ -284,7 +287,7 @@ GameLayout::GameLayout(Game& game_logic) : game_logic_(game_logic),
 }
 
 /**
- * @brief 渲染函数��FTXUI每一帧都会调用。
+ * @brief 渲染函数：FTXUI每一帧都会调用。
  * @details 负责根据当前游戏状态同步UI，并组合所有子组件来构建最终的界面布局。
  */
 Element GameLayout::Render() {
@@ -294,7 +297,7 @@ Element GameLayout::Render() {
     // 更新剧情控制器
     game_logic_.getStoryController().update();
 
-    // 状态同步：根据Game状��切换Tab的显示，并动态更新内容
+    // 状态同步：根据Game状态切换Tab的显示，并动态更新内容
     GameState state = game_logic_.getCurrentState();
     auto requestOpt = game_logic_.getCurrentInputRequest();
     lastInputPrompt_ = " 指令 ";
@@ -308,7 +311,7 @@ Element GameLayout::Render() {
             selectedInputMode_ = 2;
             if (requestOpt) {
                 lastInputPrompt_ = requestOpt->prompt;
-                // 动态更新���项按钮
+                // 动态更新选项按钮
                 if (choiceContainer_->ChildCount() != requestOpt->choices.size()) {
                     choiceContainer_->DetachAllChildren();
                     for (int i = 0; i < requestOpt->choices.size(); ++i) {
@@ -353,7 +356,7 @@ Element GameLayout::Render() {
 }
 
 bool GameLayout::isAnyPopupActive() const {
-    return showBag_ || showPhone_ || showMap_ || showShop_ || showInfo_ || showSettings_;
+    return showBag_ || showPhone_ || showMap_ || showShop_ || showInfo_ || showSettings_ || showSkillTree_;
 }
 
 GameLayout::~GameLayout() = default;

--- a/src/game/main/basic/ui/GameLayout.h
+++ b/src/game/main/basic/ui/GameLayout.h
@@ -9,12 +9,10 @@
 #include <string>
 
 class Game;
-
 class BagLayout;
-
 class MapLayout;
-
 class SettingsLayout;
+class SkillTreeLayout;
 
 /**
  * @class GameLayout
@@ -63,6 +61,7 @@ private:
     bool showShop_ = false;
     bool showInfo_ = false;
     bool showSettings_ = false;
+    bool showSkillTree_ = false;
 
     // --- 子组件成员 ---
     ftxui::Component interactiveMainView_;            ///< 可交互的对话历史显示区。
@@ -79,6 +78,7 @@ private:
     ftxui::Component shopLayout_;                     ///< 网购界面组件
     ftxui::Component infoLayout_;                     ///< 个人信息组件
     ftxui::Component settingsLayout_;                 ///< 设置组件
+    ftxui::Component skillTreeLayout_;                ///< 技能树组件
     ftxui::Component topLevelContainer_;              ///< 添加一个顶层容器
 };
 

--- a/src/game/main/basic/ui/SkillTreeLayout.cpp
+++ b/src/game/main/basic/ui/SkillTreeLayout.cpp
@@ -1,0 +1,177 @@
+#include "SkillTreeLayout.h"
+#include "../Game.h"
+#include "../../class/entity/Player.h"
+#include "ftxui/dom/elements.hpp"
+#include <algorithm>
+#include <map>
+#include <set>
+#include <string>
+#include <vector>
+
+using namespace ftxui;
+
+SkillTreeLayout::SkillTreeLayout(Game& game_logic, bool& isShowingFlag)
+    : game_logic_(game_logic), isShowingFlag_(isShowingFlag), currentPage_(0)  {
+
+    exitButton_ = Button("[  返 回  ]", [this] {
+        isShowingFlag_ = false;
+        currentPage_ = 0;
+    });
+
+    pagePrevButton_ = Button("< 上一页", [this] {
+        if (currentPage_ > 0) {
+            currentPage_--;
+        }
+    });
+
+    pageNextButton_ = Button("下一页 >", [this] {
+        const std::vector<std::vector<std::string>> blueprint = getBlueprint();
+        constexpr int columnsPerPage = 10;
+        const int totalColumns = blueprint.empty() ? 0 : blueprint[0].size();
+        const int totalPages = (totalColumns + columnsPerPage - 1) / columnsPerPage;
+        if (currentPage_ < totalPages - 1) {
+            currentPage_++;
+        }
+    });
+
+    mainContainer_ = Container::Vertical({exitButton_, pagePrevButton_, pageNextButton_});
+    Add(mainContainer_);
+}
+
+Element SkillTreeLayout::buildSkillTreeGraph() const {
+    const auto& player = game_logic_.getPlayer();
+    const auto& learnedSkills = player.getLearnedSkillNames();
+    const std::set<std::string> learnedSet(learnedSkills.begin(), learnedSkills.end());
+
+    constexpr int CELL_WIDTH = 12;
+    constexpr int CELL_HEIGHT = 1;
+    constexpr int columnsPerPage = 8;
+
+    // 动态获取技能元素
+    auto createSkillElement = [&](const std::string& name) {
+        const bool isLearned = learnedSet.contains(name);
+        const bool canLearn = player.canLearnSkill(name);
+
+        auto style = color(Color::White);
+        if (isLearned) {
+            style = color(Color::Green);
+        } else if (canLearn) {
+            style = color(Color::Yellow);
+        }
+
+        return text(name) | style | center | size(WIDTH, EQUAL, CELL_WIDTH) | size(HEIGHT, EQUAL, CELL_HEIGHT);
+    };
+
+    // 技能映射
+    const std::map<std::string, std::string> skillMap = {
+        {"_S01_", "直拳"}, {"_S02_", "踢腿"}, {"_A01_", "高踢腿"}, {"_A02_", "屹立不倒"}, {"_A03_", "反手重拳"},
+        {"_A04_", "空手道高踢腿"}, {"_A05_", "空手道踢腿"}, {"_A06_", "空手道劈斩"}, {"_A07_", "闪击"},
+        {"_A08_", "屹立不倒2"}, {"_A09_", "迅速"}, {"_A10_", "钝兵挫锐"}, {"_A11_", "屹立不倒3"},
+        {"_B01_", "重拳"}, {"_B02_", "肉食跑者"}, {"_B03_", "反手直拳"}, {"_B04_", "爪击"},
+        {"_B05_", "自杀式袭击"}, {"_B06_", "折背"}, {"_B07_", "千手不破"}, {"_B08_", "肉食跑者2"},
+        {"_B09_", "迅击"}, {"_B10_", "意志"}, {"_B11_", "无限能量"}, {"_B12_", "肉食跑者3"},
+        {"_C01_", "上钩拳"}, {"_C02_", "肌肉记忆"}, {"_C03_", "交叉拳"}, {"_C04_", "拳术直拳"},
+        {"_C05_", "肌肉记忆2"}, {"_C06_", "蓄力上钩拳"}, {"_C07_", "近战缠斗"}, {"_C08_", "人身重锤"},
+        {"_C09_", "激励"}, {"_C10_", "拳击手"}, {"_C11_", "肌肉记忆3"}
+    };
+
+    // 连接符映射
+    const std::map<std::string, std::string> connectorMap = {
+        {"→", "───────────→"},
+        {"─", "────────────"},
+        {"│", "      │     "},
+        {"┤", "──────┤     "},
+        {"├", "      ├─────"},
+        {"┌", "      ┌─────"},
+        {"└", "      └─────"},
+        {"┐", "──────┐     "},
+        {"┘", "──────┘     "},
+        {"┼", "──────┼─────"}
+    };
+
+    const auto& blueprint = getBlueprint();
+    int totalColumns = blueprint.empty() ? 0 : blueprint[0].size();
+    int startCol = currentPage_ * columnsPerPage;
+    int endCol = std::min(startCol + columnsPerPage, totalColumns);
+
+    Elements renderedRows;
+    for (const auto& rowBlueprint : blueprint) {
+        Elements rowElements;
+        for (int i = startCol; i < endCol; ++i) {
+            const auto& placeholder = rowBlueprint[i];
+            if (skillMap.contains(placeholder)) {
+                rowElements.push_back(createSkillElement(skillMap.at(placeholder)));
+            } else if (placeholder == "_BLANK_") {
+                rowElements.push_back(text("") | size(WIDTH, EQUAL, CELL_WIDTH));
+            } else if (connectorMap.contains(placeholder)) {
+                rowElements.push_back(text(connectorMap.at(placeholder)) | center | size(WIDTH, EQUAL, CELL_WIDTH));
+            } else {
+                rowElements.push_back(text("") | size(WIDTH, EQUAL, CELL_WIDTH));
+            }
+        }
+        renderedRows.push_back(hbox(std::move(rowElements)));
+    }
+
+    return vbox(std::move(renderedRows)) | hcenter;
+}
+
+Element SkillTreeLayout::Render() {
+    auto title = text(" 技 能 树 ") | bold | hcenter;
+
+    auto legend = hbox({
+        text("图例: "),
+        text("■") | color(Color::Green), text(" 已学习  "),
+        text("■") | color(Color::Yellow), text(" 可学习  "),
+        text("■") | color(Color::White), text(" 未激活"),
+    }) | hcenter;
+
+    auto treeContent = buildSkillTreeGraph();
+
+    // 导航栏
+    const auto& blueprint = getBlueprint();
+    constexpr int columnsPerPage = 10;
+    const int totalColumns = blueprint.empty() ? 0 : blueprint[0].size();
+    const int totalPages = (totalColumns + columnsPerPage - 1) / columnsPerPage;
+    const std::string pageInfo = "第 " + std::to_string(currentPage_ + 1) + " / " + std::to_string(totalPages) + " 页";
+
+    auto navigation = hbox({
+        pagePrevButton_->Render(),
+        filler(),
+        text(pageInfo) | center,
+        filler(),
+        pageNextButton_->Render(),
+    });
+
+    auto treeWindow = window(title, vbox(Elements{
+        legend,
+        separator(),
+        treeContent | flex,
+    }));
+
+    return dbox(Elements{
+        filler() | bgcolor(Color::Black),
+        vbox(Elements{
+            treeWindow | flex,
+            navigation | center,
+            exitButton_->Render() | hcenter,
+            text(" "),
+        }),
+    });
+}
+
+const std::vector<std::vector<std::string>>& SkillTreeLayout::getBlueprint() const {
+    static const std::vector<std::vector<std::string>> blueprint = {
+        {"_BLANK_", "_BLANK_", "_BLANK_", "_BLANK_", "_BLANK_", "_BLANK_", "_BLANK_", "_BLANK_", "┌", "→", "_A05_", "→", "_A07_", "→", "_A08_", "┐", "_BLANK_", "_BLANK_", "_BLANK_", "_BLANK_", "_BLANK_", "_BLANK_"},
+        {"_BLANK_", "┌", "→", "_A01_", "→", "_A02_", "→", "_A03_", "┤", "_BLANK_", "_BLANK_", "_BLANK_", "_BLANK_", "_BLANK_", "_BLANK_", "├", "→", "_A09_", "→", "_A10_", "→", "_A11_"},
+        {"_BLANK_", "│", "_BLANK_", "_BLANK_", "_BLANK_", "_BLANK_", "_BLANK_", "_BLANK_", "└", "→", "_A04_", "→", "_A06_", "─", "─", "┘", "_BLANK_", "_BLANK_", "_BLANK_", "_BLANK_", "_BLANK_", "_BLANK_"},
+        {"_S01_", "┤", "_BLANK_", "_BLANK_", "_BLANK_", "_BLANK_", "_BLANK_", "_BLANK_", "_BLANK_", "_BLANK_", "_BLANK_", "_BLANK_", "_BLANK_", "_BLANK_", "_BLANK_", "_BLANK_", "_BLANK_", "_BLANK_", "_BLANK_", "_BLANK_", "_BLANK_", "_BLANK_"},
+        {"_BLANK_", "│", "_BLANK_", "_BLANK_", "_BLANK_", "_BLANK_", "_BLANK_", "_BLANK_", "┌", "→", "_B04_", "→", "_B06_", "→", "_B08_", "┐", "_BLANK_", "_BLANK_", "_BLANK_", "_BLANK_", "_BLANK_", "_BLANK_"},
+        {"_BLANK_", "├", "→", "_B01_", "→", "_B02_", "→", "_B03_", "┤", "_BLANK_", "_BLANK_", "_BLANK_", "_BLANK_", "_BLANK_", "_BLANK_", "├", "→", "_B10_", "→", "_B11_", "→", "_B12_"},
+        {"_BLANK_", "│", "_BLANK_", "_BLANK_", "_BLANK_", "_BLANK_", "_BLANK_", "_BLANK_", "└", "→", "_B05_", "→", "_B07_", "→", "_B09_", "┘", "_BLANK_", "_BLANK_", "_BLANK_", "_BLANK_", "_BLANK_", "_BLANK_"},
+        {"_S02_", "┤", "_BLANK_", "_BLANK_", "_BLANK_", "_BLANK_", "_BLANK_", "_BLANK_", "_BLANK_", "_BLANK_", "_BLANK_", "_BLANK_", "_BLANK_", "_BLANK_", "_BLANK_", "_BLANK_", "_BLANK_", "_BLANK_", "_BLANK_", "_BLANK_", "_BLANK_", "_BLANK_"},
+        {"_BLANK_", "│", "_BLANK_", "_BLANK_", "_BLANK_", "_BLANK_", "_BLANK_", "_BLANK_", "┌", "→", "_C04_", "→", "_C07_", "→", "_C08_", "┐", "_BLANK_", "_BLANK_", "_BLANK_", "_BLANK_", "_BLANK_", "_BLANK_"},
+        {"_BLANK_", "└", "→", "_C01_", "→", "_C02_", "→", "_C03_", "┼", "→", "_C05_", "─", "─", "─", "─", "┼", "→", "_C09_", "→", "_C10_", "→", "_C11_"},
+        {"_BLANK_", "_BLANK_", "_BLANK_", "_BLANK_", "_BLANK_", "_BLANK_", "_BLANK_", "_BLANK_", "└", "→", "_C06_", "─", "─", "─", "─", "┘", "_BLANK_", "_BLANK_", "_BLANK_", "_BLANK_", "_BLANK_", "_BLANK_"},
+    };
+    return blueprint;
+}

--- a/src/game/main/basic/ui/SkillTreeLayout.h
+++ b/src/game/main/basic/ui/SkillTreeLayout.h
@@ -1,0 +1,38 @@
+// File: D:/CODE/2025_OUC_MUDGAME/src/game/main/basic/ui/SkillTreeLayout.h
+
+#ifndef SKILLTREELAYOUT_H
+#define SKILLTREELAYOUT_H
+
+#include "ftxui/component/component.hpp"
+
+class Game;
+
+/**
+ * @class SkillTreeLayout
+ * @brief 实现了只读技能树可视化功能的FTXUI组件。
+ */
+class SkillTreeLayout : public ftxui::ComponentBase {
+public:
+    explicit SkillTreeLayout(Game& game_logic, bool& isShowingFlag);
+    ftxui::Element Render() override;
+
+private:
+    // 辅助函数，用于生成FTXUI的graph元素
+    [[nodiscard]] ftxui::Element buildSkillTreeGraph() const;
+
+    Game& game_logic_;
+    bool& isShowingFlag_;
+
+    int currentPage_ = 0;
+
+    // UI组件
+    ftxui::Component exitButton_;
+    ftxui::Component mainContainer_;
+    ftxui::Component pagePrevButton_;
+    ftxui::Component pageNextButton_;
+
+    // Add this helper function declaration
+    [[nodiscard]] const std::vector<std::vector<std::string>>& getBlueprint() const;
+};
+
+#endif // SKILLTREELAYOUT_H


### PR DESCRIPTION
翻页式技能树，替换「我的日程」按钮，具体显示效果依终端字体而异
<img width="2560" height="1270" alt="image" src="https://github.com/user-attachments/assets/2d1d9397-a955-4a2b-a47e-672d3c48f19e" />
<img width="1393" height="1067" alt="image" src="https://github.com/user-attachments/assets/0760747d-f314-4760-ad4a-dd8199dfa666" />
<img width="1076" height="615" alt="image" src="https://github.com/user-attachments/assets/9ba739ed-0c66-4d76-911f-8d6d135d88de" />
